### PR TITLE
Rename git -> obot

### DIFF
--- a/make/configure.mk
+++ b/make/configure.mk
@@ -5,11 +5,11 @@
 
 # Build path
 BUILD_DIR = build
-ifndef GIT_VERSION
-GIT_VERSION := $(shell git describe --long --dirty --always --abbrev=7)
+ifndef OBOT_VERSION
+OBOT_VERSION := $(shell git describe --long --dirty --always --abbrev=7)
 endif
-ifndef GIT_HASH
-GIT_HASH := $(shell git rev-parse HEAD)
+ifndef OBOT_HASH
+OBOT_HASH := $(shell git rev-parse HEAD)
 endif
 MOTORLIB_HASH := $(shell git -C $(SELF_DIR) rev-parse HEAD)
 $(shell touch $(SELF_DIR)../param_default.h)
@@ -74,8 +74,8 @@ $(SELF_DIR)../peripheral/stm32g4/clock_config.cpp\
 endif # MCU_TARGET == stm32g474
 
 override C_DEFS +=  \
--DGIT_VERSION=\"$(GIT_VERSION)\" \
--DGIT_HASH=\"$(GIT_HASH)\" \
+-DOBOT_VERSION=\"$(OBOT_VERSION)\" \
+-DOBOT_HASH=\"$(OBOT_HASH)\" \
 -DMOTORLIB_HASH=\"$(MOTORLIB_HASH)\" \
 -DCONFIG=\"$(CONFIG)\"
 ifdef NOTES

--- a/make/make_param.mk
+++ b/make/make_param.mk
@@ -1,7 +1,7 @@
-ifndef GIT_HASH
-GIT_HASH := $(shell git rev-parse HEAD)
+ifndef OBOT_HASH
+OBOT_HASH := $(shell git rev-parse HEAD)
 endif
-GIT_DEFINE := -DGIT_HASH=\"$(GIT_HASH)\"
+GIT_DEFINE := -DOBOT_HASH=\"$(OBOT_HASH)\"
 
 ifdef PARAM_OVERRIDE
 PARAM_SUFFIX=$(addprefix _,$(notdir $(PARAM_OVERRIDE:.h=)))

--- a/param_default.h
+++ b/param_default.h
@@ -1,1 +1,1 @@
-.git_hash = GIT_HASH,
+.obot_hash = OBOT_HASH,

--- a/peripheral/stm32f4/otg_usb.cpp
+++ b/peripheral/stm32f4/otg_usb.cpp
@@ -253,7 +253,7 @@ void USB_OTG::handle_setup_packet(uint8_t *setup_data) {
                                     break;
                                 }
                                 case 0x04:
-                                    send_string(0, GIT_HASH " " BUILD_DATETIME, std::strlen(GIT_HASH " " BUILD_DATETIME));
+                                    send_string(0, OBOT_HASH " " BUILD_DATETIME, std::strlen(OBOT_HASH " " BUILD_DATETIME));
                                     break;
                                 case 0x05:
                                     send_string(0, name, std::strlen(name));

--- a/peripheral/stm32g4/usb.cpp
+++ b/peripheral/stm32g4/usb.cpp
@@ -461,7 +461,7 @@ void USB1::interrupt() {
                                     break;
                                 }
                                 case 0x04:
-                                    send_string(0, GIT_VERSION " " BUILD_DATETIME, std::strlen(GIT_VERSION " " BUILD_DATETIME));
+                                    send_string(0, OBOT_VERSION " " BUILD_DATETIME, std::strlen(OBOT_VERSION " " BUILD_DATETIME));
                                     break;
                                 case 0x05:
                                     send_string(0, const_cast<const char*>(name), std::strlen(const_cast<const char*>(name)));

--- a/system.h
+++ b/system.h
@@ -20,8 +20,8 @@ class System {
  public:
     static void run() {
         // check parameter version
-        if (GIT_HASH != std::string(param->git_hash)) {
-            logger.log_printf("param version error, firmware: %s, param: %s", GIT_HASH, param->git_hash);
+        if (OBOT_HASH != std::string(param->obot_hash)) {
+            logger.log_printf("param version error, firmware: %s, param: %s", OBOT_HASH, param->obot_hash);
             actuator_.main_loop_.led_.set_color(LED::RED);
             actuator_.main_loop_.led_.set_mode(LED::BLINKING);
             while(1) {
@@ -29,7 +29,7 @@ class System {
                 NVIC_SystemReset();
             }
         } else {
-            logger.log_printf("param version match: %s", GIT_HASH);
+            logger.log_printf("param version match: %s", OBOT_HASH);
         }
         actuator_.start();
 
@@ -237,9 +237,9 @@ class System {
         api.add_api_variable("timestamp", new const APICallbackUint32(get_clock));
         api.add_api_variable("mrollover", new const APICallbackFloat([](){ return actuator_.fast_loop_.get_rollover(); }));
         api.add_api_variable("gear_ratio", new const APIFloat(&param->startup_param.gear_ratio));
-        api.add_api_variable("version", new const APICallback([](){ return GIT_VERSION; }));
-        api.add_api_variable("git_sha", new const APICallback([](){ return GIT_HASH; }));
-        api.add_api_variable("motorlib_sha", new const APICallback([](){ return MOTORLIB_HASH; }));
+        api.add_api_variable("version", new const APICallback([](){ return OBOT_VERSION; }));
+        api.add_api_variable("obot_hash", new const APICallback([](){ return OBOT_HASH; }));
+        api.add_api_variable("motorlib_hash", new const APICallback([](){ return MOTORLIB_HASH; }));
         api.add_api_variable("name", new const APICallback([](){ return param->name; }));
         uint32_t api_timeout_us = 10000;
         api.add_api_variable("api_timeout", new APIUint32(&api_timeout_us));


### PR DESCRIPTION
Rename git_hash and git_version to obot_hash and obot_version better clarity when using alternate versioning schemes.