### PR TITLE
max_i_bias parameter

### DIFF
--- a/fast_loop.h
+++ b/fast_loop.h
@@ -244,6 +244,7 @@ class FastLoop {
       ia_bias_ = param_.ia_bias;
       ib_bias_ = param_.ib_bias;
       ic_bias_ = param_.ic_bias;
+      max_i_bias_ = param_.max_i_bias == 0 ? 10 : param_.max_i_bias;
       iq_filter_.set_frequency(param_.output_filter_hz.iq);
       motor_velocity_filter_.set_frequency(param_.output_filter_hz.motor_velocity);
       motor_position_filter_.set_frequency(param_.output_filter_hz.motor_position);
@@ -282,9 +283,9 @@ class FastLoop {
       ia_bias_ = (1-alpha_zero_)*(ia_bias_) + alpha_zero_* param_.adc1_gain*(adc1_0-2048);
       ib_bias_ = (1-alpha_zero_)*(ib_bias_) + alpha_zero_* param_.adc2_gain*(adc2_0-2048);
       ic_bias_ = (1-alpha_zero_)*(ic_bias_) + alpha_zero_* param_.adc3_gain*(adc3_0-2048);
-      ia_bias_ = fsat(ia_bias_, 10);
-      ib_bias_ = fsat(ib_bias_, 10);
-      ic_bias_ = fsat(ic_bias_, 10);
+      ia_bias_ = fsat(ia_bias_, max_i_bias_);
+      ib_bias_ = fsat(ib_bias_, max_i_bias_);
+      ic_bias_ = fsat(ic_bias_, max_i_bias_);
     }
 
     void set_phase_mode(float phase_mode) {
@@ -344,6 +345,7 @@ class FastLoop {
     int32_t motor_mechanical_position_ = 0;
 
     float ia_bias_, ib_bias_, ic_bias_;
+    float max_i_bias_ = 0;
 
     float iq_des = 0;
     float id_des = 0;

--- a/messages.h
+++ b/messages.h
@@ -59,6 +59,7 @@ typedef struct {
 
 typedef struct {
     float ia_bias, ib_bias, ic_bias;                // initial guess at current sensor bias in amps
+    float max_i_bias;                               // maximum allowable current sensor bias during auto biasing (A) default 10
     float adc1_gain, adc2_gain, adc3_gain;          // current sensor linear gain units A/count
     FOCParam foc_param;
     uint8_t phase_mode;     // two possible motor wiring states: 0: standard, 1: reverse (i.e. two motor leads flipped)


### PR DESCRIPTION
Necessary for some bench testing experiments. The existing 10 A limit is a safety so that an unknown issue can't drive the PWM too crazy.