### PR TITLE
Feature/pz clear

### DIFF
--- a/icpz.h
+++ b/icpz.h
@@ -143,14 +143,11 @@ class ICPZ : public EncoderBase {
           //pos_ = data/256;
           last_data_ = data;
         }
-        if (!diag.nErr && auto_clear_diag) {
-          switch (clear_diag_command_active_) {
-            case 0:
-              read_diag_no_wait();
-              break;
-            case 1:
-              clear_diag_no_wait();
-              break;
+        if (auto_clear_diag) {
+          if (clear_diag_command_active_ == 1) {
+            clear_diag_no_wait();
+          } else if (!diag.nErr) {
+            read_diag_no_wait();
           }
         }
         ongoing_read_ = false;

--- a/icpz.h
+++ b/icpz.h
@@ -29,6 +29,8 @@ static uint8_t CRC_BiSS_43_30bit (uint32_t w_InputData);
     api.add_api_variable(prefix "raw", new APIUint32(&icpz.raw_value_));\
     api.add_api_variable(prefix "rawh", new const APICallback([](){ return u32_to_hex(icpz.raw_value_); }));\
     api.add_api_variable(prefix "diag", new const APICallback([](){ return icpz.read_diagnosis(); }));\
+    api.add_api_variable(prefix "clear_diag", new const APICallback([](){ icpz.clear_diag(); return "ok"; }));\
+    api.add_api_variable(prefix "auto_clear_diag", new APIBool(&icpz.auto_clear_diag));\
     api.add_api_variable(prefix "conf_write", new const APICallback([](){ return icpz.write_conf(); }));\
     api.add_api_variable(prefix "auto_ana", new const APICallback([](){ icpz.start_auto_adj_ana(); return "ok"; }));\
     api.add_api_variable(prefix "auto_dig", new const APICallback([](){ icpz.start_auto_adj_dig(); return "ok"; }));\
@@ -134,8 +136,8 @@ class ICPZ : public EncoderBase {
           //pos_ = data/256;
           last_data_ = data;
         }
-        if (!diag.nErr) {
-          //clear_diag();
+        if (!diag.nErr && auto_clear_diag) {
+          clear_diag();
         }
         ongoing_read_ = false;
       }
@@ -159,7 +161,6 @@ class ICPZ : public EncoderBase {
       uint8_t data_in[10];
       spidma_.readwrite(data_out, data_in, 10, true);
       (*register_operation_)--;
-      clear_diag();
       return bytes_to_hex(data_in+2, 8);
     }
 
@@ -506,6 +507,7 @@ class ICPZ : public EncoderBase {
     uint32_t warn_count_ = 0;
     uint32_t crc_error_count_ = 0;
     uint32_t raw_value_ = 0;
+    bool auto_clear_diag = true;
     friend void config_init();
     friend void config_maintenance();
 


### PR DESCRIPTION
Add auto read and clear of PZ diag status. A cached version of diag is available on from read_diagnosis. This adds jitter to the loop in which it is used.