### PR TITLE
remove malloc from isr

### DIFF
--- a/boards/config_obot_g474_motor.h
+++ b/boards/config_obot_g474_motor.h
@@ -4,6 +4,7 @@
 #include <string>
 #include "../otp.h"
 #include "st_device.h"
+#include "../peripheral/stm32_serial.h"
 
 struct BoardRev {
     enum Rev {kR0, kR1, kR2, kR3, kR4, kMR0, kMR0P, kMR1, kMR2} rev;
@@ -18,6 +19,7 @@ struct BoardRev {
 };
 
 BoardRev get_board_rev() {
+    init_serial_number();
     BoardRev b = {};
     enum BoardRev::Rev& rev = b.rev;
 

--- a/boards/config_obot_g474_motor_40.cpp
+++ b/boards/config_obot_g474_motor_40.cpp
@@ -23,11 +23,13 @@ using Driver = DriverMPS;
 #include "pin_config_obot_g474_motor_40.h"
 #include "../peripheral/stm32g4/temp_sensor.h"
 #include "../peripheral/stm32g4/max31875.h"
+#include "../peripheral/stm32_serial.h"
 
 extern "C" void SystemClock_Config();
 void pin_config_obot_g474_motor_40();
 
 extern "C" void board_init() {
+    init_serial_number();
     SystemClock_Config();
     pin_config_obot_g474_motor_40();
 }

--- a/boards/config_obot_g474_osa.cpp
+++ b/boards/config_obot_g474_osa.cpp
@@ -24,11 +24,13 @@ uint16_t drv_regs_error = 0;
 #include "pin_config_obot_g474_osa.h"
 #include "../peripheral/stm32g4/temp_sensor.h"
 #include "../peripheral/stm32g4/max31875.h"
+#include "../peripheral/stm32_serial.h"
 
 extern "C" void SystemClock_Config();
 void pin_config_obot_g474_osa();
 
 extern "C" void board_init() {
+    init_serial_number();
     SystemClock_Config();
     pin_config_obot_g474_osa();
 }

--- a/icpz.h
+++ b/icpz.h
@@ -90,6 +90,8 @@ class ICPZ : public EncoderBase {
       success = set_register(0, 0, {3}) ? success : false; // fast speed on port a, set first
       success = set_register(7, 9, {0}) ? success : false; // multiturn data length = 0
       success = set_register(7, 0xA, {0}) ? success : false; // spi_ext = 0
+      success &= set_register(7, 0, {0x13, 0x07, 0, 0x11}); // disable prc error, default: {0x13, 0x0F, 0, 0x11}, 
+      success &= set_register(7, 4, {0x0C, 0xC8, 0, 0x02}); // prc is a warning, default: {0x0C, 0xC0, 0, 0x02}, 
       success = set_register(0, 0xF, {4}) ? success : false; // 0x00 ran_fld = 0 -> never update position based on absolute track after initial, tol 4
       success = set_register(2, 3, {0x77}) ? success : false; // moderate dynamic digital calibration
       success = set_register(2, 0, {0x77, 0x7}) ? success: false; // moderate dynamic analog calibration
@@ -249,7 +251,8 @@ class ICPZ : public EncoderBase {
     }
 
     void clear_faults() {
-        clear_diag();
+        // todo this is called by mainloop needs to be isr safe to use clear diag here
+        // clear_diag();
         error_count_ = 0;
         warn_count_ = 0;
         crc_error_count_ = 0;

--- a/main_loop.h
+++ b/main_loop.h
@@ -176,14 +176,15 @@ class MainLoop {
       if (status_.error.all & error_mask_.all && !(receive_data_.mode_desired == DRIVER_ENABLE || receive_data_.mode_desired == CLEAR_FAULTS)) {
           status_.error.fault = 1;
           if (safe_mode_ != true) {
-            logger.log_printf("fault detected, error: %08x", status_.error.all);
-            std::string s = "fault bits:";
-            for (int i=0; i<32; i++) {
-              if ((status_.error.all >> i) & 0x1) {
-                s += " " + error_bit_strings[i];
-              }
-            }
-            logger.log(s);
+            // todo bring back logger in isr safe way
+            // logger.log_printf("fault detected, error: %08x", status_.error.all);
+            // std::string s = "fault bits:";
+            // for (int i=0; i<32; i++) {
+            //   if ((status_.error.all >> i) & 0x1) {
+            //     s += " " + error_bit_strings[i];
+            //   }
+            // }
+            // logger.log(s);
           }
           safe_mode_ = true;
           set_mode(param_.safe_mode);
@@ -602,7 +603,8 @@ class MainLoop {
           led_.set_color(LED::RED);
           led_.set_rate(2);
           if (param_.safe_mode_driver_disable && !(mode == DRIVER_ENABLE)) {
-            logger.log_printf("safe mode driver disable, mode: %d", mode);
+            // todo bring back logger in isr safe way
+            // logger.log_printf("safe mode driver disable, mode: %d", mode);
             driver_.disable();
           }
         } else {

--- a/peripheral/stm32_serial.h
+++ b/peripheral/stm32_serial.h
@@ -2,4 +2,5 @@
 
 #include <string>
 // get the stm32 12 byte ascii hex serial number
-std::string get_serial_number();
+const char * get_serial_number();
+void init_serial_number();

--- a/peripheral/stm32f4/stm32f4_serial.cpp
+++ b/peripheral/stm32f4/stm32f4_serial.cpp
@@ -6,7 +6,7 @@
 #define         DEVICE_ID3          (UID_BASE + 8) 
 
 // This is the serial number used by the bootloader, 12 bytes
-std::string get_serial_number() {
+const char * get_serial_number() {
   uint32_t deviceserial0, deviceserial1, deviceserial2;
 
   deviceserial0 = *(uint32_t *)DEVICE_ID1;
@@ -16,6 +16,7 @@ std::string get_serial_number() {
   deviceserial0 += deviceserial2;
   char buffer[13];
   std::sprintf(buffer,"%lX%X",deviceserial0, (uint16_t) (deviceserial1>>16));
-  std::string s(buffer);
-  return s;
+  return buffer;
 }
+
+void init_serial_number() {}

--- a/peripheral/stm32g4/drv8323s.h
+++ b/peripheral/stm32g4/drv8323s.h
@@ -43,17 +43,18 @@ class DRV8323S : public DriverBase {
 
     void disable() {
         uint32_t status = get_drv_status();
-        logger.log_printf("drv8323 disabled, status1: %03x status2: %03x", status & 0xFFFF, status >> 16);
-        std::string s = "drv8323 status bits";
-        for(int i=0; i<11; i++) {
-            if ((status >> i) & 0x1)
-                s += " " + drv8323_status1_bits[i];
-        }
-        for(int i=0; i<11; i++) {
-            if ((status >> (16+i)) & 0x1)
-                s += " " + drv8323_status2_bits[i];
-        }
-        logger.log(s);
+        // todo bring back logger in isr safe way
+        // logger.log_printf("drv8323 disabled, status1: %03x status2: %03x", status & 0xFFFF, status >> 16);
+        // std::string s = "drv8323 status bits";
+        // for(int i=0; i<11; i++) {
+        //     if ((status >> i) & 0x1)
+        //         s += " " + drv8323_status1_bits[i];
+        // }
+        // for(int i=0; i<11; i++) {
+        //     if ((status >> (16+i)) & 0x1)
+        //         s += " " + drv8323_status2_bits[i];
+        // }
+        // logger.log(s);
         GPIOC->BSRR = GPIO_BSRR_BR13; // drv disable
         DriverBase::disable();
     }

--- a/peripheral/stm32g4/stm32g4_serial.cpp
+++ b/peripheral/stm32g4/stm32g4_serial.cpp
@@ -3,10 +3,12 @@
 
 #define         DEVICE_ID1          (UID_BASE) //(0x1FFF7A10)
 #define         DEVICE_ID2          (UID_BASE + 4) 
-#define         DEVICE_ID3          (UID_BASE + 8) 
+#define         DEVICE_ID3          (UID_BASE + 8)
+
+static char serial_number[13];
 
 // This is the serial number used by the bootloader, 12 bytes
-std::string get_serial_number() {
+void init_serial_number() {
   uint32_t deviceserial0, deviceserial1, deviceserial2;
 
   deviceserial0 = *(uint32_t *)DEVICE_ID1;
@@ -14,8 +16,10 @@ std::string get_serial_number() {
   deviceserial2 = *(uint32_t *)DEVICE_ID3;
 
   deviceserial0 += deviceserial2;
-  char buffer[13];
-  std::sprintf(buffer,"%lX%X",deviceserial0, (uint16_t) (deviceserial1>>16));
-  std::string s(buffer);
-  return s;
+  
+  std::sprintf(serial_number,"%lX%X",deviceserial0, (uint16_t) (deviceserial1>>16));
+}
+
+const char * get_serial_number() {
+  return serial_number;
 }


### PR DESCRIPTION
temporary fix remove dynamic memory in isrs
- malloc is not safe to use in isrs unless a critical section is defined for it
- logger is not safe to use in isrs right now due to this
- moved serial number to non-dynamic in usb isr
- moved PRC fault to warning so that clear_diag is not as critical in isr clear_faults call