### PR TITLE
Feature/spi dma timeout

### DIFF
--- a/main_loop.h
+++ b/main_loop.h
@@ -46,13 +46,19 @@ class MainLoop {
           iq_find_limits_filter_(1.0/frequency_hz, 1), motor_velocity_filter_(1.0/frequency_hz, param.output_filter_hz.motor_velocity), motor_position_filter_(1.0/frequency_hz),
           output_position_filter_(1.0/frequency_hz), output_velocity_filter_(1.0/frequency_hz, param.output_filter_hz.output_velocity), torque_filter_(1.0/frequency_hz) {
           set_param();
+#ifdef END_TRIGGER_MAIN_SENSORS
+          output_encoder_.trigger();
+          torque_sensor_.trigger();
+#endif
         }
     void init() {} // todo: init filters with first status
     void update() {
       count_++;
-
+#ifndef END_TRIGGER_MAIN_SENSORS
       output_encoder_.trigger();
       torque_sensor_.trigger();
+#endif
+
 
       if (count_ >= frequency_hz_) {
         count_ = 0;
@@ -398,6 +404,10 @@ class MainLoop {
       led_.update();
       //last_receive_data_ = receive_data_;
       IWDG->KR = 0xAAAA;
+#ifdef END_TRIGGER_MAIN_SENSORS
+      output_encoder_.trigger();
+      torque_sensor_.trigger();
+#endif
     }
 
 

--- a/main_loop.h
+++ b/main_loop.h
@@ -54,7 +54,7 @@ class MainLoop {
     void init() {} // todo: init filters with first status
     void update() {
       count_++;
-#ifndef END_TRIGGER_MAIN_SENSORS
+#if !defined(END_TRIGGER_MAIN_SENSORS) && !defined(EXT_TRIGGER_MAIN_SENSORS)
       output_encoder_.trigger();
       torque_sensor_.trigger();
 #endif


### PR DESCRIPTION
- Better timeout for spi transactions - i.e. a few bits past when the transaction should be complete rather than 100 us.
- Also add an sensor end trigger option for main loop. This allows executing the spi dma transaction in the background rather than waiting.