### PR TITLE
Feature/spi dma

### DIFF
--- a/ads1235.h
+++ b/ads1235.h
@@ -12,11 +12,8 @@ class ADS1235 : public TorqueSensorBase {
  public:
     enum PGAGain {GAIN_1=0, GAIN_64=6, GAIN_128=7};
     enum SPS {SPS_2_5=0, SPS_10=2, SPS_100=7, SPS_1200=9, SPS_2400=10, SPS_4800=11, SPS_7200=12};
-    ADS1235(SPIDMA &spidma, PGAGain pga_gain = GAIN_128, SPS sps = SPS_1200, volatile int* register_operation = nullptr) : 
+    ADS1235(SPIDMA &spidma, PGAGain pga_gain = GAIN_128, SPS sps = SPS_1200) : 
         spidma_(spidma), pga_gain_(pga_gain) {
-            if (register_operation != nullptr) {
-                register_operation_ = register_operation;
-            }
       command_[0] = 0x12;
       constructor_init(sps);
     }
@@ -31,34 +28,29 @@ class ADS1235 : public TorqueSensorBase {
       return init_val_;
     }
     void trigger() {
-      if (!*register_operation_) {
-        spidma_.start_readwrite(command_, data_, 5);
-      }
+      spidma_.start_readwrite(command_, data_, 5);
     }
     float read() {
-      if (!*register_operation_) {
-        spidma_.finish_readwrite();
-        int32_t torque_int = signextend<int32_t, 24>((data_[2]) << 16 | (data_[3] << 8) | data_[4]);
-        torque_ = gain_*torque_int;
-      }
+      spidma_.finish_readwrite();
+      int32_t torque_int = signextend<int32_t, 24>((data_[2]) << 16 | (data_[3] << 8) | data_[4]);
+      torque_ = gain_*torque_int;
       return torque_;
     }
-    volatile int *register_operation_ = &register_operation_local_;
  protected:
 
     uint8_t read_register(uint8_t address) {
-        (*register_operation_)++;
+        spidma_.claim();
         uint8_t command[3] = {(uint8_t) (0x20u+address)};
         uint8_t data_in[3];
         spidma_.readwrite(command, data_in, 3);
-        (*register_operation_)--;
+        spidma_.release();
         return data_in[2];
     }
 
     // non interrupt context
     // returns true for success
     bool set_register(uint8_t address, uint8_t value) {
-        (*register_operation_)++;
+        spidma_.claim();
         bool retval = true;
         if (read_register(address) != value) {
             uint8_t command[2] = {(uint8_t) (0x40+address), value};
@@ -66,14 +58,13 @@ class ADS1235 : public TorqueSensorBase {
             spidma_.readwrite(command, data_in, 2);
             retval = read_register(address) == value;
         }
-        (*register_operation_)--;
+        spidma_.release();
         return retval;
     }
 
     SPIDMA &spidma_;
     uint8_t command_[5] = {};
     uint8_t data_[5] = {};
-    volatile int register_operation_local_ = 0;
     PGAGain pga_gain_;
     uint32_t init_val_ = 0;
 

--- a/ads1235_2.h
+++ b/ads1235_2.h
@@ -6,8 +6,8 @@
 
 class ADS1235_2 : public ADS1235 {
  public:
-    ADS1235_2(SPIDMA &spidma, volatile int* register_operation = nullptr) : 
-        ADS1235(spidma, register_operation) {
+    ADS1235_2(SPIDMA &spidma) : 
+        ADS1235(spidma) {
     }
     uint32_t init() {
       uint32_t retval = ADS1235::init();

--- a/bmi270.h
+++ b/bmi270.h
@@ -16,7 +16,6 @@ class BMI270 {
         int16_t gyr_x, gyr_y, gyr_z;
     };
     BMI270(SPIDMA &spi_dma) : spi_dma_(spi_dma) {
-        register_operation_ = spi_dma_.register_operation_;
     }
     void init() {
         write_reg(0x7C, 0x00);
@@ -35,11 +34,11 @@ class BMI270 {
         write_reg(0x7C, 0x02);
     }
 
-    void read(bool register_operation = false) {
+    void read() {
         //data_out_[0] = 0x80; // chip id
 
         data_out_[0] = 0x8c;
-        spi_dma_.readwrite(data_out_, data_in_, 14, register_operation);
+        spi_dma_.readwrite(data_out_, data_in_, 14);
         // logger.log(bytes_to_hex(data_in_, 14));
         data_.acc_x = (int16_t) (data_in_[3] << 8 | data_in_[2]);
         data_.acc_y = (int16_t) (data_in_[5] << 8 | data_in_[4]);
@@ -55,7 +54,7 @@ class BMI270 {
     void read_with_restore() {
         (*register_operation_)++;
         spi_dma_.save_state();
-        read(true);
+        read();
         spi_dma_.restore_state();
         (*register_operation_)--;
     }
@@ -64,10 +63,10 @@ class BMI270 {
         (*register_operation_)++;
         uint8_t data_out[1] = {address};
         uint8_t data_in[1];
-        spi_dma_.start_readwrite(data_out, data_in, 1, true);
+        spi_dma_.start_readwrite(data_out, data_in, 1);
         us_delay(2);
-        spi_dma_.start_write(data, length, true);
-        spi_dma_.finish_readwrite(true);
+        spi_dma_.start_write(data, length);
+        spi_dma_.finish_readwrite();
         us_delay(3);
         (*register_operation_)--;
     }
@@ -76,7 +75,7 @@ class BMI270 {
         (*register_operation_)++;
         uint8_t data_out[2] = {address, value};
         uint8_t data_in[2];
-        spi_dma_.readwrite(data_out, data_in, 2, true);
+        spi_dma_.readwrite(data_out, data_in, 2);
         us_delay(3);
         (*register_operation_)--;
     }
@@ -85,7 +84,7 @@ class BMI270 {
         (*register_operation_)++;
         uint8_t data_out[3] = {(uint8_t) (address | 0x80)};
         uint8_t data_in[3];
-        spi_dma_.readwrite(data_out, data_in, 3, true);
+        spi_dma_.readwrite(data_out, data_in, 3);
         us_delay(3);
         (*register_operation_)--;
         return data_in[2];

--- a/boards/config_obot_g474_motor.cpp
+++ b/boards/config_obot_g474_motor.cpp
@@ -131,7 +131,7 @@ extern "C" void board_init() {
 namespace config {
     static_assert(((double) CPU_FREQUENCY_HZ * 8 / 2) / pwm_frequency < 65535);    // check pwm frequency
 #ifdef SPI1_REINIT_CALLBACK
-    DRV8323S drv(*SPI1, spi1_dma.register_operation_, spi1_reinit_callback);
+    DRV8323S drv(*SPI1);//, spi1_dma.register_operation_, spi1_reinit_callback);
 #else
     DRV8323S drv(*SPI1);
 #endif
@@ -150,7 +150,7 @@ namespace config {
 
     // has_bmi270
     GPIO imu_cs(*GPIOC, 4, GPIO::OUTPUT);
-    SPIDMA spi1_dma_bmi270(*SPI1, imu_cs, *DMA1_Channel3, *DMA1_Channel4, 40, 40, drv.register_operation_,
+    SPIDMA spi1_dma_bmi270(SPIDMA::SP1, imu_cs, DMA1_CH3, DMA1_CH4, 1000, 40, 40,
         SPI_CR1_MSTR | (4 << SPI_CR1_BR_Pos) | SPI_CR1_SSI | SPI_CR1_SSM);    // baud = clock/32
     BMI270 imu(spi1_dma_bmi270);
 

--- a/boards/config_obot_g474_motor.cpp
+++ b/boards/config_obot_g474_motor.cpp
@@ -435,7 +435,7 @@ void system_init() {
         return config::motor_pwm.deadtime_ns_; }, [](uint16_t u) {config::motor_pwm.set_deadtime(u); }));
 
     if (config::board_rev.has_bmi270) {
-        System::api.add_api_variable("imu_read", new const APICallback([](){ config::imu.read_with_restore(); return config::imu.get_string(); }));
+        System::api.add_api_variable("imu_read", new const APICallback([](){ return config::imu.get_string(); }));
         System::api.add_api_variable("ax", new const APICallbackFloat([](){ return config::imu.data_.acc_x*8./pow(2,15); }));
         System::api.add_api_variable("ay", new const APICallbackFloat([](){ return config::imu.data_.acc_y*8./pow(2,15); }));
         System::api.add_api_variable("az", new const APICallbackFloat([](){ return config::imu.data_.acc_z*8./pow(2,15); }));

--- a/boards/config_obot_g474_motor.cpp
+++ b/boards/config_obot_g474_motor.cpp
@@ -130,11 +130,8 @@ extern "C" void board_init() {
 
 namespace config {
     static_assert(((double) CPU_FREQUENCY_HZ * 8 / 2) / pwm_frequency < 65535);    // check pwm frequency
-#ifdef SPI1_REINIT_CALLBACK
-    DRV8323S drv(*SPI1);//, spi1_dma.register_operation_, spi1_reinit_callback);
-#else
-    DRV8323S drv(*SPI1);
-#endif
+    DRV8323S drv(*SPI1, SPIDMA::spi_pause[SPIDMA::SP1]);
+
     TempSensor temp_sensor;
     I2C_DMA i2c1(*I2C1, *DMA1_Channel7, *DMA1_Channel8, 400);
     

--- a/doc/sensors.md
+++ b/doc/sensors.md
@@ -1,0 +1,68 @@
+# Sensors
+
+Sensors are required for the operation of the motor controller. There are a few required sensors for each loop.
+
+- fast_loop
+    - motor_encoder
+
+- main_loop
+    - output_encoder
+    - torque_sensor
+
+Each loop is run at a defined frequency and is run in an interrupt context. The sensor api required by the fast and main
+loop are `void trigger()` and `int32_t/float read()`. The trigger function is called early in the loop before some other
+processing, then read is called to reap the results. Other sensors may be added and read from the system_loop or main()
+context. Often sensors share a common peripheral, which makes coordinating these loops more difficult. One solution is
+to use SensorMultiplex and to make the primary sensor in the faster loop. Another solution is to use DMA to set up a
+background read of sensors.
+
+## Asynchronous reads
+
+Often sensors also have diagnostic data. If one wishes to read this diagnostic data asynchronously to the sensor reads,
+there are a few options. Sensors based on SPI may use the SPIPause feature which will temporarily pause sensor reads in
+the interrupt context such that diagnostic data can be read in the main() context. SPIPause only supports two contexts,
+main() and interrupt. It does not work to use SPIPause to read from two different interrupts of different priorities.
+SPIPause will work to coordinate reads between main() and the interrupt both with blocking sensor reads and continuous
+DMA reads. In both cases the interrupt data will be temporarily paused while getting the diagnostic data. SPIPause is
+currently built in to the SPIDMA class and can be accessed from that class using `claim()` and `release()`. This system
+is designed for efficiency in the interrupt context and requires extra overhead when used from the main() context for
+diagnostics. SPIPause is a set of global exclusive locks, they can be accessed directly at
+`SPIDMA::spi_pause[SPIDMA::SPx]`. Sometimes it is preferable to have diagnostic data read without pausing sensor reads.
+In this case it is best to try to interleave diagnostic reads with sensor reads during the main sensor read. The ICPZDMA
+class provides an example of this. 
+
+### SPIPause example
+
+```cpp
+struct Sensor {
+    ...
+    void read() {
+        // if paused this readwrite will skip (not block) and not update the outputs
+        spidma_.readwrite(...);
+    }
+    int get_diag() {
+        spidma_.claim();
+        spidma_.readwrite(...);
+        spidma_.release();
+    }
+    SPIDMA &spidma_;
+};
+
+SPIDMA spi1_dma1(SPI1, ...);u
+Sensor sensor1(spi1_dma1);
+SPIDMA spi1_dma2(SPI1, ...);
+Sensor sensor2(spi1_dma2);
+
+void isr() {
+    sensor1.read();
+    sensor2.read();
+}
+
+void main() {
+    while(1) {
+        ms_delay(1000);
+        // will pause both isr reads() until complete
+        sensor1.get_diag();
+    }
+}
+```

--- a/ma732_encoder.h
+++ b/ma732_encoder.h
@@ -18,7 +18,7 @@ class MA732Encoder : public SPIEncoder {
         } bits;
         uint16_t word;
     };
-    MA732Encoder(SPI_TypeDef &regs, GPIO &gpio_cs, SPIPause spi_pause, uint8_t filter = 119) : SPIEncoder(regs, gpio_cs), 
+    MA732Encoder(SPI_TypeDef &regs, GPIO &gpio_cs, SPIPause &spi_pause, uint8_t filter = 119) : SPIEncoder(regs, gpio_cs), 
         filter_(filter), regs_(regs), spi_pause_(spi_pause) {
         reinit();
     }
@@ -155,7 +155,7 @@ class MA732Encoder : public SPIEncoder {
     SPI_TypeDef &regs_;
     uint16_t last_data_ = 0;
     int32_t count_ = 0;
-    SPIPause spi_pause_;
+    SPIPause &spi_pause_;
     uint32_t tmp;
 };
 

--- a/ma732_encoder.h
+++ b/ma732_encoder.h
@@ -4,6 +4,7 @@
 #include "peripheral/spi_encoder.h"
 #include "util.h"
 #include "logger.h"
+#include "peripheral/spi_dma.h"
 
 // Note MA732 encoder expects cpol 1, cpha 1, max 25 mbit
 // 80 ns cs start to sclk, 25 ns sclk end to cs end
@@ -17,35 +18,30 @@ class MA732Encoder : public SPIEncoder {
         } bits;
         uint16_t word;
     };
-    MA732Encoder(SPI_TypeDef &regs, GPIO &gpio_cs, uint8_t filter = 119, volatile int *register_operation = nullptr) : SPIEncoder(regs, gpio_cs), filter_(filter), regs_(regs) {
-        if (register_operation != nullptr) {
-            register_operation_ = register_operation;
-        }
+    MA732Encoder(SPI_TypeDef &regs, GPIO &gpio_cs, SPIPause spi_pause, uint8_t filter = 119) : SPIEncoder(regs, gpio_cs), 
+        filter_(filter), regs_(regs), spi_pause_(spi_pause) {
         reinit();
     }
 
     void reinit() {
-        if (!*register_operation_) {
 #ifdef STM32F446xx
-            regs_.CR1 = SPI_CR1_MSTR | (3 << SPI_CR1_BR_Pos) | SPI_CR1_SSI | SPI_CR1_SSM | SPI_CR1_SPE | SPI_CR1_DFF;    // baud = clock/16, 16 bit
+        regs_.CR1 = SPI_CR1_MSTR | (3 << SPI_CR1_BR_Pos) | SPI_CR1_SSI | SPI_CR1_SSM | SPI_CR1_SPE | SPI_CR1_DFF;    // baud = clock/16, 16 bit
 #else    
-            regs_.CR2 = (15 << SPI_CR2_DS_Pos);   // 16 bit
-            regs_.CR1 = SPI_CR1_MSTR | (3 << SPI_CR1_BR_Pos) | SPI_CR1_SSI | SPI_CR1_SSM | SPI_CR1_SPE;    // baud = clock/16
+        regs_.CR2 = (15 << SPI_CR2_DS_Pos);   // 16 bit
+        regs_.CR1 = SPI_CR1_MSTR | (3 << SPI_CR1_BR_Pos) | SPI_CR1_SSI | SPI_CR1_SSM | SPI_CR1_SPE;    // baud = clock/16
 #endif
-            
-        }
     }
 
     // interrupt context
     void trigger()  __attribute__((section (".ccmram"))) {
-        if (!*register_operation_) {
+        if (!spi_pause_.is_paused()) {
             SPIEncoder::trigger();
         }
     }
 
     // interrupt context   
     int32_t read()  __attribute__((section (".ccmram"))) {
-        if (!*register_operation_) {
+        if (!spi_pause_.is_paused()) {
             SPIEncoder::read();
             count_ += (int16_t) (data_ - last_data_); // rollover summing
             last_data_ = data_;
@@ -55,22 +51,22 @@ class MA732Encoder : public SPIEncoder {
 
     // non interrupt context
     virtual uint8_t read_register(uint8_t address) {
+        spi_pause_.pause();
         reinit(); // only really necessary if there are multiple users of the spi
-        (*register_operation_)++;
         MA732reg reg = {};
         reg.bits.address = address;
         reg.bits.command = 0b010; // read register
         send_and_read(reg.word);
         ns_delay(750); // read register delay
         uint8_t retval = send_and_read(0) >> 8;
-        (*register_operation_)--;
+        spi_pause_.unpause();
         return retval;
     }
 
     // non interrupt context
     virtual bool set_register(uint8_t address, uint8_t value) {
         reinit();
-        (*register_operation_)++;
+        spi_pause_.pause();
         bool retval = true;
         if (read_register(address) != value) {
             MA732reg reg = {};
@@ -85,7 +81,7 @@ class MA732Encoder : public SPIEncoder {
                 logger.log_printf("ma732 set reg %x: %x, read %x", address, value, read_value);
             }
         }
-        (*register_operation_)--;
+        spi_pause_.unpause();
         return retval;
     }
 
@@ -159,8 +155,7 @@ class MA732Encoder : public SPIEncoder {
     SPI_TypeDef &regs_;
     uint16_t last_data_ = 0;
     int32_t count_ = 0;
-    volatile int register_operation_local_ = 0;
-    volatile int *register_operation_ = &register_operation_local_;
+    SPIPause spi_pause_;
     uint32_t tmp;
 };
 

--- a/ma782_encoder.h
+++ b/ma782_encoder.h
@@ -9,8 +9,8 @@
 class MA782Encoder final : public MA732Encoder {
  public:
     enum MA782FW {_1, _2, _4, _8, _16, _32, _64, _128, _256, _512, _1024, _2048, _4096}; // us
-    MA782Encoder(SPI_TypeDef &regs, GPIO &gpio_cs, SPIPause spi_pause, uint8_t filter = _512) : 
-        MA732Encoder(regs, gpio_cs, filter, spi_pause) {}
+    MA782Encoder(SPI_TypeDef &regs, GPIO &gpio_cs, SPIPause &spi_pause, uint8_t filter = _512) : 
+        MA732Encoder(regs, gpio_cs, spi_pause, filter) {}
     
     virtual void set_filt(uint32_t value) override {
         set_register(0xE, value << 4);

--- a/make/configure.mk
+++ b/make/configure.mk
@@ -72,7 +72,9 @@ $(SELF_DIR)../peripheral/stm32g4/stm32g4_serial.cpp\
 $(SELF_DIR)../peripheral/stm32g4/usb.cpp\
 $(SELF_DIR)../peripheral/stm32g4/spi_slave.cpp\
 $(SELF_DIR)../peripheral/stm32g4/spi_slave_figure.cpp\
-$(SELF_DIR)../peripheral/stm32g4/uart.cpp
+$(SELF_DIR)../peripheral/stm32g4/uart.cpp\
+$(SELF_DIR)../peripheral/stm32g4/spi_dma.cpp\
+
 
 endif # MCU_TARGET == stm32g474
 

--- a/peripheral/spi_dma.h
+++ b/peripheral/spi_dma.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <cstdint>
+
+class Lock {
+    public:
+    void wait_lock() {
+        unsigned tmp = 0;
+        do {
+            asm volatile("ldrex     %1, %0\n\t"
+                         "add       %1, #1\n\t"
+                         "strex     %1, %1, %0" : "+m" (lock_), "=r" (tmp) : "m" (lock_));
+        } while (tmp == 0);
+    }
+    void unlock() {
+        unsigned tmp;
+        asm volatile("ldrex     %1, %0\n\t"
+                     "sub       %1, #1\n\t"
+                     "strex     %1, %1, %0" : "+m" (lock_), "=r" (tmp) : "m" (lock_));
+    }
+    bool try_lock() {
+        unsigned tmp;
+        asm volatile("ldrex     %1, %0\n\t"
+                     "add       %1, #1\n\t"
+                     "strex     %1, %1, %0" : "+m" (lock_), "=r" (tmp) : "m" (lock_));
+        return tmp == 1;
+    }
+    bool is_locked() {
+        asm volatile("" : "=m" (lock_));
+        return lock_ > 0;
+    }
+    private:
+    unsigned lock_ = 0;
+};
+
+
+template <class T>
+class SPIDMABase {
+ public:
+    SPIDMABase(uint32_t baudrate, Lock &lock) : lock_(lock) {
+        reinit();
+    }
+
+    void reinit() {
+        static_cast<T*>(this)->reinit();
+    }
+
+    void save_state() {
+        static_cast<T*>(this)->save_state();
+    }
+
+    void restore_state() {
+        static_cast<T*>(this)->restore_state();
+    }
+
+    void readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint16_t length) {
+        start_readwrite(data_out, data_in, length);
+        finish_readwrite();
+    }
+
+    // Note, use memory barrier before accesing data_in
+    // Example: asm("" : "=m" (*(uint8_t (*)[]) data_in));
+    void start_continuous_readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint16_t length) {
+        lock_.wait_lock();
+        asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
+        static_cast<T*>(this)->start_continuous_readwrite(data_out, data_in, length);
+    }
+
+    void start_continuous_write(const uint8_t * const data_out, uint16_t length) {
+        lock_.wait_lock();
+        asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
+        static_cast<T*>(this)->start_continuous_write(data_out, length);
+    }
+
+    void stop_continuous_readwrite() {
+        static_cast<T*>(this)->stop_continuous_readwrite();
+        lock_.unlock();
+    }
+
+    // call only if guaranteed not to be interrupted
+    void start_readwrite_isr(const uint8_t * const data_out, uint8_t * const data_in, uint16_t length) {
+        if (!lock_.is_locked()) {
+            reinit();
+            asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
+            static_cast<T*>(this)->start_readwrite(data_out, data_in, length);
+            asm("" : "=m" (*(uint8_t (*)[]) data_in));
+        }
+    }
+
+    void start_readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint16_t length) {
+        if (lock_.try_lock()) {
+            reinit();
+            asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
+            static_cast<T*>(this)->start_readwrite(data_out, data_in, length);
+            asm("" : "=m" (*(uint8_t (*)[]) data_in));
+        }
+    }
+
+    void start_write(const uint8_t * const data_out, uint16_t length) {
+        if (lock_.try_lock()) {
+            reinit();
+            asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
+            static_cast<T*>(this)->start_write(data_out, length);
+        }
+    }
+
+    void finish_readwrite() {
+        if (lock_.is_locked()) {
+            static_cast<T*>(this)->finish_readwrite();
+            lock_.unlock();
+        }
+        
+    }
+
+    Lock &lock_;
+
+};

--- a/peripheral/spi_dma.h
+++ b/peripheral/spi_dma.h
@@ -18,7 +18,8 @@ class SPIPause {
     bool is_paused() {
         return lock_ > 0;
     }
-    std::function<void()> stop_callback_, start_callback_;
+    std::function<void()> stop_callback_ = []{};
+    std::function<void()> start_callback_ = []{};
  private:
     unsigned lock_ = 0;
     

--- a/peripheral/spi_dma.h
+++ b/peripheral/spi_dma.h
@@ -33,15 +33,7 @@ class SPIDMABase {
     }
 
     void reinit() {
-        static_cast<T*>(this)->reinit();
-    }
-
-    void save_state() {
-        static_cast<T*>(this)->save_state();
-    }
-
-    void restore_state() {
-        static_cast<T*>(this)->restore_state();
+        static_cast<T*>(this)->reinit_impl();
     }
 
     void readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint16_t length) {
@@ -53,23 +45,23 @@ class SPIDMABase {
     // Example: asm("" : "=m" (*(uint8_t (*)[]) data_in));
     void start_continuous_readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint16_t length) {
         asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
-        static_cast<T*>(this)->start_continuous_readwrite(data_out, data_in, length);
+        static_cast<T*>(this)->start_continuous_readwrite_impl(data_out, data_in, length);
     }
 
     void start_continuous_write(const uint8_t * const data_out, uint16_t length) {
         asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
-        static_cast<T*>(this)->start_continuous_write(data_out, length);
+        static_cast<T*>(this)->start_continuous_write_impl(data_out, length);
     }
 
     void stop_continuous_readwrite() {
-        static_cast<T*>(this)->stop_continuous_readwrite();
+        static_cast<T*>(this)->stop_continuous_readwrite_impl();
     }
 
     void start_readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint16_t length) {
         if (!pause_.is_paused() || claimed_) {
             reinit();
             asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
-            static_cast<T*>(this)->start_readwrite(data_out, data_in, length);
+            static_cast<T*>(this)->start_readwrite_impl(data_out, data_in, length);
             asm("" : "=m" (*(uint8_t (*)[]) data_in));
         }
     }
@@ -78,13 +70,13 @@ class SPIDMABase {
         if (!pause_.is_paused() || claimed_) {
             reinit();
             asm("" : : "m" (*(const uint8_t (*)[]) data_out)); // ensure data_out[] is in memory
-            static_cast<T*>(this)->start_write(data_out, length);
+            static_cast<T*>(this)->start_write_impl(data_out, length);
         }
     }
 
     void finish_readwrite() {
         if (!pause_.is_paused()) {
-            static_cast<T*>(this)->finish_readwrite();
+            static_cast<T*>(this)->finish_readwrite_impl();
         }
     }
 

--- a/peripheral/spi_dma.h
+++ b/peripheral/spi_dma.h
@@ -21,7 +21,7 @@ class SPIPause {
     std::function<void()> stop_callback_ = []{};
     std::function<void()> start_callback_ = []{};
  private:
-    unsigned lock_ = 0;
+    volatile unsigned lock_ = 0;
     
 };
 

--- a/peripheral/stm32g4/dma.h
+++ b/peripheral/stm32g4/dma.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "st_device.h"
+
+ enum DMA_CHANNEL_INSTANCE {
+        DMA1_CH1,
+        DMA1_CH2,
+        DMA1_CH3,
+        DMA1_CH4,
+        DMA1_CH5,
+        DMA1_CH6,
+        DMA1_CH7,
+        DMA1_CH8,
+        DMA2_CH1,
+        DMA2_CH2,
+        DMA2_CH3,
+        DMA2_CH4,
+        DMA2_CH5,
+        DMA2_CH6,
+        DMA2_CH7,
+        DMA2_CH8,
+        NUM_DMA_CHANNELS,
+};
+static constexpr DMA_Channel_TypeDef *dma_ch_regs[NUM_DMA_CHANNELS] = {
+    DMA1_Channel1, DMA1_Channel2, DMA1_Channel3, DMA1_Channel4,
+    DMA1_Channel5, DMA1_Channel6, DMA1_Channel7, DMA2_Channel8,
+    DMA2_Channel1, DMA2_Channel2, DMA2_Channel3, DMA2_Channel4, 
+    DMA2_Channel5, DMA2_Channel6, DMA2_Channel7, DMA2_Channel8,
+};

--- a/peripheral/stm32g4/drv8323s.h
+++ b/peripheral/stm32g4/drv8323s.h
@@ -4,6 +4,7 @@
 #include "../../driver.h"
 #include "../../logger.h"
 #include "../../parameter_api.h"
+#include "../spi_dma.h"
 
 extern uint16_t drv_regs_error;
 
@@ -12,15 +13,12 @@ static const std::string drv8323_status2_bits[11] = {"vgs_lc", "vgs_hc", "vgs_lb
 
 class DRV8323S : public DriverBase {
  public:
-    DRV8323S(SPI_TypeDef &regs, volatile int* register_operation = nullptr, void (*spi_reinit_callback)() = nullptr)
-        : regs_(regs), spi_reinit_callback_(spi_reinit_callback) {
-        if (register_operation != nullptr) {
-            register_operation_ = register_operation;
-        }
+    DRV8323S(SPI_TypeDef &regs, SPIPause &spi_pause)
+        : regs_(regs), spi_pause_(spi_pause) {
     }
 
     void drv_spi_start() {
-        (*register_operation_)++;
+        spi_pause_.pause();
         GPIO_SETL(A, 4, 2, 3, 5); // pin A4 NSS
         regs_.CR1 = 0; // clear SPE
         regs_.CR2 = (15 << SPI_CR2_DS_Pos) | SPI_CR2_FRF;   // 16 bit TI mode
@@ -35,10 +33,7 @@ class DRV8323S : public DriverBase {
         GPIOA->BSRR = GPIO_ODR_OD4;
 
         // SPI needs reinit
-        if (spi_reinit_callback_ != nullptr) {
-            spi_reinit_callback_();
-        }
-        (*register_operation_)--;
+        spi_pause_.unpause();
     }
 
     void disable() {
@@ -134,7 +129,6 @@ class DRV8323S : public DriverBase {
 
             return value;
     }
-    volatile int *register_operation_ = &register_operation_local_;
 
     void set_debug_variables(ParameterAPI &api) {
         api.add_api_variable("drv_idrivep_hs", new APICallbackUint8([this](){ return this->get_idrivep_hs(); },
@@ -203,8 +197,7 @@ class DRV8323S : public DriverBase {
 
  private:
     SPI_TypeDef &regs_;
-    volatile int register_operation_local_ = 0;
-    void (*spi_reinit_callback_)();
+    SPIPause &spi_pause_;
 };
 
 #endif  // UNHUMAN_MOTORLIB_PERIPHERAL_STM32G4_DRV8323S_H_

--- a/peripheral/stm32g4/spi_debug.h
+++ b/peripheral/stm32g4/spi_debug.h
@@ -8,30 +8,25 @@
 
 class SPIDebug {
  public:
-    SPIDebug(SPIDMA &spi_dma, volatile int* register_operation = nullptr) : 
-        spi_dma_(spi_dma) {
-            if (register_operation != nullptr) {
-                register_operation_ = register_operation;
-            }
-        }
+    SPIDebug(SPIDMA &spi_dma) : 
+        spi_dma_(spi_dma) {}
 
     std::string read() {
-        (*register_operation_)++;
+        spi_dma_.claim();
         std::vector<char> data_out = hex_to_bytes(hex_str_);
         std::vector<char> data_in(data_out.size(), 0);
         spi_dma_.readwrite((uint8_t *) data_out.data(), (uint8_t *) data_in.data(), hex_str_.size()/2);
-        (*register_operation_)--;
+        spi_dma_.release();
         return "in " + std::to_string(data_in.size()) + " " + bytes_to_hex(data_in);
     }
 
     void write(std::string hex_str) {
         hex_str_ = hex_str;
     }
-    volatile int * register_operation_ = &register_operation_local_;
+
   private:
     SPIDMA &spi_dma_;
     std::string hex_str_ = "";
-    volatile int register_operation_local_;
 
     friend void config_init();
 };

--- a/peripheral/stm32g4/spi_dma.cpp
+++ b/peripheral/stm32g4/spi_dma.cpp
@@ -1,3 +1,3 @@
 #include "spi_dma.h"
 
-Lock SPIDMA::spi_lock[NUM_SPIS]{};
+SPIPause SPIDMA::spi_pause[NUM_SPIS]{};

--- a/peripheral/stm32g4/spi_dma.cpp
+++ b/peripheral/stm32g4/spi_dma.cpp
@@ -1,0 +1,3 @@
+#include "spi_dma.h"
+
+Lock SPIDMA::spi_lock[NUM_SPIS]{};

--- a/peripheral/stm32g4/spi_dma.h
+++ b/peripheral/stm32g4/spi_dma.h
@@ -19,12 +19,12 @@ class SPIDMA : public SPIDMABase<SPIDMA> {
     };
 
     static constexpr SPI_TypeDef *spi_regs[NUM_SPIS] = {SPI1, SPI2, SPI3, SPI4};
-    static Lock spi_lock[NUM_SPIS];
+    static SPIPause spi_pause[NUM_SPIS];
 
     SPIDMA(SPI_INSTANCE inst, GPIO &gpio_cs, DMA_CHANNEL_INSTANCE tx_channel, DMA_CHANNEL_INSTANCE rx_channel, 
         uint32_t baudrate,
         uint16_t start_cs_delay_ns = 100, uint16_t end_cs_delay_ns = 100, uint32_t regs_cr1 = 0) : 
-        SPIDMABase(baudrate, spi_lock[inst]),
+        SPIDMABase(baudrate, spi_pause[inst]),
         regs_(*spi_regs[inst]), gpio_cs_(gpio_cs),
         tx_dma_(*dma_ch_regs[tx_channel]), rx_dma_(*dma_ch_regs[rx_channel]),
         start_cs_delay_ns_(start_cs_delay_ns), end_cs_delay_ns_(end_cs_delay_ns),

--- a/peripheral/stm32g4/spi_dma.h
+++ b/peripheral/stm32g4/spi_dma.h
@@ -2,24 +2,38 @@
 #define UNHUMAN_MOTORLIB_PERIPHERAL_STM32G4_SPI_DMA_H_
 
 #include <cstdint>
+#include "../spi_dma.h"
+#include "dma.h"
 #include "st_device.h"
 #include "../../gpio.h"
 #include "../../util.h"
-
-class SPIDMA {
+#include "../../logger.h"
+class SPIDMA : public SPIDMABase<SPIDMA> {
  public:
-    SPIDMA(SPI_TypeDef &regs, GPIO &gpio_cs, DMA_Channel_TypeDef &tx_dma, DMA_Channel_TypeDef &rx_dma, 
-        uint16_t start_cs_delay_ns = 100, uint16_t end_cs_delay_ns = 100, volatile int *register_operation = nullptr, uint32_t regs_cr1 = 0) : 
-        regs_(regs), gpio_cs_(gpio_cs),
-        tx_dma_(tx_dma), rx_dma_(rx_dma),
+    enum SPI_INSTANCE {
+        SP1,
+        SP2,
+        SP3,
+        SP4,
+        NUM_SPIS,
+    };
+
+    static constexpr SPI_TypeDef *spi_regs[NUM_SPIS] = {SPI1, SPI2, SPI3, SPI4};
+    static Lock spi_lock[NUM_SPIS];
+
+    SPIDMA(SPI_INSTANCE inst, GPIO &gpio_cs, DMA_CHANNEL_INSTANCE tx_channel, DMA_CHANNEL_INSTANCE rx_channel, 
+        uint32_t baudrate,
+        uint16_t start_cs_delay_ns = 100, uint16_t end_cs_delay_ns = 100, uint32_t regs_cr1 = 0) : 
+        SPIDMABase(baudrate, spi_lock[inst]),
+        regs_(*spi_regs[inst]), gpio_cs_(gpio_cs),
+        tx_dma_(*dma_ch_regs[tx_channel]), rx_dma_(*dma_ch_regs[rx_channel]),
         start_cs_delay_ns_(start_cs_delay_ns), end_cs_delay_ns_(end_cs_delay_ns),
         regs_cr1_(regs_cr1) {
-            if (register_operation != nullptr) {
-                register_operation_ = register_operation;
-            }
+
             if (regs_cr1 == 0) {
-                regs_cr1_ = regs.CR1;
+                regs_cr1_ = regs_.CR1;
             }
+        logger.log_printf("SPI%d init, desired baudrate: %d, applied baudrate: %d", inst+1, baudrate, baudrate);
         reinit();
     }
 
@@ -46,14 +60,8 @@ class SPIDMA {
         regs_.CR1 = old_cr1_;
     }
 
-    void readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint8_t length, bool register_operation = false) {
-        start_readwrite(data_out, data_in, length, register_operation);
-        finish_readwrite(register_operation);
-    }
-
     void start_continuous_readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint8_t length) {
         length_ = length;
-        asm("nop"); // memory barrier data_out[]
         tx_dma_.CCR = 0;
         rx_dma_.CCR = 0;
         tx_dma_.CNDTR = length;
@@ -77,56 +85,45 @@ class SPIDMA {
         rx_dma_.CCR = 0;
     }
 
-    void start_readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint8_t length, bool register_operation = false) {
-        if (!*register_operation_ || register_operation) {
-            reinit();
-            gpio_cs_.clear();
-            ns_delay(start_cs_delay_ns_);
-            length_ = length;
-            tx_dma_.CCR = 0;
-            rx_dma_.CCR = 0;
-            tx_dma_.CNDTR = length;
-            rx_dma_.CNDTR = length;
-            tx_dma_.CMAR = (uint32_t) data_out;
-            rx_dma_.CMAR = (uint32_t) data_in;      
-            rx_dma_.CCR = DMA_CCR_EN | DMA_CCR_MINC;
-            tx_dma_.CCR = DMA_CCR_EN | DMA_CCR_MINC | DMA_CCR_DIR; // DIR = 1 > read from memory
-            time_start_ = get_clock();
-            asm("dmb"); // ensure that CMAR writes are not optimized out
-        }
+    void start_readwrite(const uint8_t * const data_out, uint8_t * const data_in, uint8_t length) {
+        gpio_cs_.clear();
+        ns_delay(start_cs_delay_ns_);
+        length_ = length;
+        tx_dma_.CCR = 0;
+        rx_dma_.CCR = 0;
+        tx_dma_.CNDTR = length;
+        rx_dma_.CNDTR = length;
+        tx_dma_.CMAR = (uint32_t) data_out;
+        rx_dma_.CMAR = (uint32_t) data_in;      
+        rx_dma_.CCR = DMA_CCR_EN | DMA_CCR_MINC;
+        tx_dma_.CCR = DMA_CCR_EN | DMA_CCR_MINC | DMA_CCR_DIR; // DIR = 1 > read from memory
+        time_start_ = get_clock();
     }
 
-    void start_write(const uint8_t * const data_out, uint16_t length, bool register_operation = false) {
-        if (!*register_operation_ || register_operation) {
-            gpio_cs_.clear();
-            ns_delay(start_cs_delay_ns_);
-            length_ = length;
-            tx_dma_.CCR = 0;
-            rx_dma_.CCR = 0;
-            tx_dma_.CNDTR = length;
-            rx_dma_.CNDTR = length;
-            tx_dma_.CMAR = (uint32_t) data_out;
-            rx_dma_.CMAR = (uint32_t) tmp_rx_;        
-            rx_dma_.CCR = DMA_CCR_EN;
-            tx_dma_.CCR = DMA_CCR_EN | DMA_CCR_MINC | DMA_CCR_DIR; // DIR = 1 > read from memory
-            time_start_ = get_clock();
-            asm("dmb"); // ensure that CMAR writes are not optimized out
-        }
+    void start_write(const uint8_t * const data_out, uint16_t length) {
+        gpio_cs_.clear();
+        ns_delay(start_cs_delay_ns_);
+        length_ = length;
+        tx_dma_.CCR = 0;
+        rx_dma_.CCR = 0;
+        tx_dma_.CNDTR = length;
+        rx_dma_.CNDTR = length;
+        tx_dma_.CMAR = (uint32_t) data_out;
+        rx_dma_.CMAR = (uint32_t) tmp_rx_;        
+        rx_dma_.CCR = DMA_CCR_EN;
+        tx_dma_.CCR = DMA_CCR_EN | DMA_CCR_MINC | DMA_CCR_DIR; // DIR = 1 > read from memory
+        time_start_ = get_clock();
     }
 
-    void finish_readwrite(bool register_operation = false) {
-        if (!*register_operation_ || register_operation) {
-            uint8_t brr = (regs_.CR1 & SPI_CR1_BR) >> SPI_CR1_BR_Pos;
-            uint32_t timeout = (length_*8+3)*(2 << brr); // 3 extra bits time
-            while(rx_dma_.CNDTR && (get_clock() - time_start_ < timeout)); // Busy wait with timeout
-            ns_delay(end_cs_delay_ns_);
-            gpio_cs_.set();
-        }
+    void finish_readwrite() {
+        uint8_t brr = (regs_.CR1 & SPI_CR1_BR) >> SPI_CR1_BR_Pos;
+        uint32_t timeout = (length_*8+3)*(2 << brr); // 3 extra bits time
+        while(rx_dma_.CNDTR && (get_clock() - time_start_ < timeout)); // Busy wait with timeout
+        ns_delay(end_cs_delay_ns_);
+        gpio_cs_.set();
     }
 
-    volatile int *register_operation_ = &register_operation_local_;
 
-    volatile int register_operation_local_ = 0;
     SPI_TypeDef &regs_;
     GPIO &gpio_cs_;
     DMA_Channel_TypeDef &tx_dma_, &rx_dma_;

--- a/peripheral/stm32g4/spi_torque.h
+++ b/peripheral/stm32g4/spi_torque.h
@@ -15,7 +15,7 @@ void system_init();
 class SPITorque final : public TorqueSensorBase {
  public:
     SPITorque(SPI_TypeDef &regs, GPIO &gpio_cs, DMA_Channel_TypeDef &tx_dma, DMA_Channel_TypeDef &rx_dma, 
-        SPIPause spi_pause, uint8_t decimation = 50) : 
+        SPIPause &spi_pause, uint8_t decimation = 50) : 
         regs_(regs), gpio_cs_(gpio_cs), 
         tx_dma_(tx_dma), rx_dma_(rx_dma), 
         spi_pause_(spi_pause), decimation_(decimation) {}
@@ -116,7 +116,7 @@ class SPITorque final : public TorqueSensorBase {
     uint32_t sum_;
     //float torque_ = 0;
     uint8_t count_ = 0;
-    SPIPause spi_pause_;
+    SPIPause &spi_pause_;
     uint8_t decimation_;
     
 

--- a/sensors/encoders/aeat9922.h
+++ b/sensors/encoders/aeat9922.h
@@ -96,7 +96,7 @@ class AEAT9922 : public EncoderBase {
     bool index_received() const { return true; }
 
     bool set_register(uint8_t address, uint8_t value) {
-        (*spidma_.register_operation_)++;
+        spidma_.claim();
         uint8_t data_out[3+isol_] = {0, address};
         data_out[2] = crc(data_out);
 
@@ -112,10 +112,10 @@ class AEAT9922 : public EncoderBase {
         data_out[0] = 0x40;
         spidma_.readwrite(data_out, data_in, 3+isol_, true);
         if (data_in[1+isol_] != data_out[1]) {
-            (*spidma_.register_operation_)--;
+            spidma_.release();
             return false;
         }
-        (*spidma_.register_operation_)--;
+        spidma_.release();
         return true;
     }
 
@@ -133,7 +133,7 @@ class AEAT9922 : public EncoderBase {
     }
 
     uint8_t get_error_register() {
-        (*spidma_.register_operation_)++;
+        spidma_.claim();
         uint8_t data_out[2] = {0x40, 0x21};
         uint8_t data_in[2];
         spidma_.readwrite(data_out, data_in, 2, true);
@@ -142,7 +142,7 @@ class AEAT9922 : public EncoderBase {
         }
         spidma_.readwrite(read_out_, read_in_, 3+isol_, true);
 
-        (*spidma_.register_operation_)--;
+        spidma_.release();
         return read_in_[1+isol_];
     }
     uint8_t crc(uint8_t data[3]) {

--- a/sensors/encoders/icpz.h
+++ b/sensors/encoders/icpz.h
@@ -169,7 +169,7 @@ class ICPZBase : public EncoderBase {
       set_register_operation();
       uint8_t data_out[10] = {0x9C};
       uint8_t data_in[10];
-      spidma_.readwrite(data_out, data_in, 10, true);
+      spidma_.readwrite(data_out, data_in, 10);
       clear_diag();
       clear_register_operation();
       return bytes_to_hex(data_in+2, 8);
@@ -177,7 +177,7 @@ class ICPZBase : public EncoderBase {
 
     void clear_diag() {
       set_register_operation();
-      set_register(bank_, Addr::COMMANDS, {SCLEAR}, true);
+      set_register(bank_, Addr::COMMANDS, {SCLEAR});
       clear_register_operation();
     }
 
@@ -190,14 +190,14 @@ class ICPZBase : public EncoderBase {
         uint8_t data_in[length+3];
         
         if (type_ == PZ) {
-          spidma_.readwrite(data_out.data(), data_in, length+3, true);
+          spidma_.readwrite(data_out.data(), data_in, length+3);
           clear_register_operation();
           return std::vector<uint8_t>(&data_in[3], &data_in[3+length]);
         } else {
-          spidma_.readwrite(data_out.data(), data_in, 2, true);
+          spidma_.readwrite(data_out.data(), data_in, 2);
           data_out[0] = 0xad;
           data_out[1] = 0;
-          spidma_.readwrite(data_out.data(), data_in, length+2, true);
+          spidma_.readwrite(data_out.data(), data_in, length+2);
           clear_register_operation();
           return std::vector<uint8_t>(&data_in[2], &data_in[2+length]);
         }
@@ -208,7 +208,7 @@ class ICPZBase : public EncoderBase {
         if (bank != bank_) {
           uint8_t data_in[3];
           uint8_t data_out[] = {write_register_opcode_, 0x40, bank};
-          spidma_.readwrite(data_out, data_in, 3, true);
+          spidma_.readwrite(data_out, data_in, 3);
           if (read_register(0x40, 1) != std::vector<uint8_t>{bank}) {
             logger.log("ichaus bank " + std::to_string(read_register(0x40, 1)[0]) + " not " + std::to_string(bank));
             clear_register_operation();
@@ -231,14 +231,14 @@ class ICPZBase : public EncoderBase {
           return std::vector<uint8_t>(1,0xff);
         }
         if (type_ == PZ) {
-          spidma_.readwrite(data_out.data(), data_in, length+3, true);
+          spidma_.readwrite(data_out.data(), data_in, length+3);
           clear_register_operation();
           return std::vector<uint8_t>(&data_in[3], &data_in[3+length]);
         } else {
-          spidma_.readwrite(data_out.data(), data_in, 2, true);
+          spidma_.readwrite(data_out.data(), data_in, 2);
           data_out[0] = 0xad;
           data_out[1] = 0;
-          spidma_.readwrite(data_out.data(), data_in, length+2, true);
+          spidma_.readwrite(data_out.data(), data_in, length+2);
           clear_register_operation();
           return std::vector<uint8_t>(&data_in[2], &data_in[2+length]);
         }
@@ -255,7 +255,7 @@ class ICPZBase : public EncoderBase {
         }
         std::vector<uint8_t> data_out = {write_register_opcode_, address};
         data_out.insert(data_out.end(), value.begin(), value.end());
-        spidma_.readwrite(data_out.data(), data_in, data_out.size(), true);
+        spidma_.readwrite(data_out.data(), data_in, data_out.size());
         if (!set_only) {
           std::vector<uint8_t> data_read = read_register(address, value.size());
           retval = data_read == value;

--- a/sensors/encoders/icpz.h
+++ b/sensors/encoders/icpz.h
@@ -152,38 +152,25 @@ class ICPZBase : public EncoderBase {
     }
     bool index_received() const { return true; }
 
-    void set_register_operation() {
-      static_cast<ConcreteICPZ*>(this)->set_register_operation_impl();
-    }
-    void set_register_operation_impl() {
-      (*register_operation_)++;
-    }
-    void clear_register_operation() {
-      static_cast<ConcreteICPZ*>(this)->clear_register_operation_impl(); 
-    }
-    void clear_register_operation_impl() {
-       (*register_operation_)--;
-    }
-
     std::string read_diagnosis() {
-      set_register_operation();
+      spidma_.claim();
       uint8_t data_out[10] = {0x9C};
       uint8_t data_in[10];
       spidma_.readwrite(data_out, data_in, 10);
       clear_diag();
-      clear_register_operation();
+      spidma_.release();
       return bytes_to_hex(data_in+2, 8);
     }
 
     void clear_diag() {
-      set_register_operation();
+      spidma_.claim();
       set_register(bank_, Addr::COMMANDS, {SCLEAR});
-      clear_register_operation();
+      spidma_.release();
     }
 
         // non interrupt context
     std::vector<uint8_t> read_register(uint8_t address, uint8_t length) {
-        set_register_operation();
+        spidma_.claim();
         std::vector<uint8_t> data_out(length+3, 0);
         data_out[0] = read_register_opcode_;
         data_out[1] = address;
@@ -191,66 +178,66 @@ class ICPZBase : public EncoderBase {
         
         if (type_ == PZ) {
           spidma_.readwrite(data_out.data(), data_in, length+3);
-          clear_register_operation();
+          spidma_.release();
           return std::vector<uint8_t>(&data_in[3], &data_in[3+length]);
         } else {
           spidma_.readwrite(data_out.data(), data_in, 2);
           data_out[0] = 0xad;
           data_out[1] = 0;
           spidma_.readwrite(data_out.data(), data_in, length+2);
-          clear_register_operation();
+          spidma_.release();
           return std::vector<uint8_t>(&data_in[2], &data_in[2+length]);
         }
     }
 
     bool set_bank(uint8_t bank) {
-        set_register_operation();
+        spidma_.claim();
         if (bank != bank_) {
           uint8_t data_in[3];
           uint8_t data_out[] = {write_register_opcode_, 0x40, bank};
           spidma_.readwrite(data_out, data_in, 3);
           if (read_register(0x40, 1) != std::vector<uint8_t>{bank}) {
             logger.log("ichaus bank " + std::to_string(read_register(0x40, 1)[0]) + " not " + std::to_string(bank));
-            clear_register_operation();
+            spidma_.release();
             return false;
           }
           bank_ = bank;
         }
-        clear_register_operation();
+        spidma_.release();
         return true;
     }
 
     std::vector<uint8_t> read_register(uint8_t bank, uint8_t address, uint8_t length) {
-        set_register_operation();
+        spidma_.claim();
         std::vector<uint8_t> data_out(length+3, 0);
         data_out[0] = read_register_opcode_;
         data_out[1] = address;
         uint8_t data_in[length+3];
         if (!set_bank(bank)) {
-          clear_register_operation();
+          spidma_.release();
           return std::vector<uint8_t>(1,0xff);
         }
         if (type_ == PZ) {
           spidma_.readwrite(data_out.data(), data_in, length+3);
-          clear_register_operation();
+          spidma_.release();
           return std::vector<uint8_t>(&data_in[3], &data_in[3+length]);
         } else {
           spidma_.readwrite(data_out.data(), data_in, 2);
           data_out[0] = 0xad;
           data_out[1] = 0;
           spidma_.readwrite(data_out.data(), data_in, length+2);
-          clear_register_operation();
+          spidma_.release();
           return std::vector<uint8_t>(&data_in[2], &data_in[2+length]);
         }
     }
 
     // non interrupt context
     bool set_register(uint8_t bank, uint8_t address, const std::vector<uint8_t> &value, bool set_only = false) {
-        set_register_operation();
+        spidma_.claim();
         bool retval = true;
         uint8_t data_in[std::max(value.size()+2,(std::size_t) 3)];
         if (!set_bank(bank)) {
-          clear_register_operation();
+          spidma_.release();
           return false;
         }
         std::vector<uint8_t> data_out = {write_register_opcode_, address};
@@ -259,14 +246,14 @@ class ICPZBase : public EncoderBase {
         if (!set_only) {
           std::vector<uint8_t> data_read = read_register(address, value.size());
           retval = data_read == value;
-          clear_register_operation();
+          spidma_.release();
           if (!retval) {
             for (unsigned int i=0; i<value.size(); i++) {
               logger.log_printf("icpz register %x, set%d: %x, read%d: %x", address, i, value[i], i, data_read[i]);
             }
           }
         } else {
-          clear_register_operation();
+          spidma_.release();
         }
         return retval;
     }

--- a/sensors/encoders/stm32g4/icpz2_dma.h
+++ b/sensors/encoders/stm32g4/icpz2_dma.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "icpz_dma.h"
+
+class ICPZ2DMA : public EncoderBase {
+ public:
+    ICPZ2DMA(ICPZ icpz, ICPZ &icpz2, DMAMUX_Channel_TypeDef &tx_dmamux, DMAMUX_Channel_TypeDef &rx_dmamux, uint8_t exti_num,
+      void(*start_cs_trigger)(), void(*stop_cs_trigger_and_wait_cs_high)()) : icpz_(icpz), icpz2_(icpz2), spidma_(icpz.spidma_), 
+      dmamux_tx_regs_(tx_dmamux), dmamux_rx_regs_(rx_dmamux), exti_num_(exti_num),
+      start_cs_trigger_(start_cs_trigger), stop_cs_trigger_and_wait_cs_high_(stop_cs_trigger_and_wait_cs_high) {
+
+      // sequence:
+      // temp1,  angle1, angle2,
+      // temp2,  angle1, angle2,
+      // diag1,  angle1, angle2,
+      // diag2,  angle1, angle2,
+      // cdiag1, angle1, angle2,
+      // cdiag2, angle1, angle2,
+
+      command_mult_[0][0][0] = 0x81; // read temperature
+      command_mult_[0][0][1] = 0x4e;
+      command_mult_[0][1][0] = 0xa6; // read position
+      command_mult_[0][2][0] = 0xa6; // read position
+
+      command_mult_[1][0][0] = 0x81; // read temperature
+      command_mult_[1][0][1] = 0x4e;
+      command_mult_[1][1][0] = 0xa6; // read position
+      command_mult_[1][2][0] = 0xa6; // read position
+
+      command_mult_[2][0][0] = 0x9c; // read diagnosis
+      command_mult_[2][1][0] = 0xa6; // read position
+      command_mult_[2][2][0] = 0xa6; // read position
+
+      command_mult_[3][0][0] = 0x9c; // read diagnosis
+      command_mult_[3][1][0] = 0xa6; // read position
+      command_mult_[3][2][0] = 0xa6; // read position
+      
+      command_mult_[4][0][0] = 0xcf; // clear diagnosis
+      command_mult_[4][0][1] = ICPZ::Addr::COMMANDS;
+      command_mult_[4][0][2] = ICPZ::CMD::SCLEAR;
+      command_mult_[4][1][0] = 0xa6; // read position
+      command_mult_[4][2][0] = 0xa6; // read position
+      
+      command_mult_[5][0][0] = 0xcf; // clear diagnosis
+      command_mult_[5][0][1] = ICPZ::Addr::COMMANDS;
+      command_mult_[5][0][2] = ICPZ::CMD::SCLEAR;
+      command_mult_[5][1][0] = 0xa6; // read position
+      command_mult_[5][2][0] = 0xa6; // read position
+    }
+
+    bool init() {
+      bool result = icpz_.init();
+      result &= icpz2_.init();
+      return result;
+    }
+    void trigger() {}
+
+    int32_t read() {
+      uint32_t current_buf_index = current_buffer_index();
+      uint8_t *data_buf1 = data_mult_[current_buf_index][1];
+      uint8_t *data_buf2 = data_mult_[current_buf_index][2];
+      int32_t value1_ = icpz_.read_buf(data_buf1);
+      int32_t value2_ = icpz2_.read_buf(data_buf2);
+
+      return value1_;
+    }
+
+
+    float get_temperature() {
+      uint8_t index=1;
+      uint8_t *data = &data_mult_[index-1][0][3];
+      return ICPZ::get_temperature(data);
+    }
+
+    uint32_t current_buffer_index() const {
+      if (spidma_.rx_dma_.CNDTR > 5*18) {
+        return 5;
+      } else if (spidma_.rx_dma_.CNDTR > 4*18) {
+        return 0;
+      } else if (spidma_.rx_dma_.CNDTR > 3*18) {
+        return 1;
+      } else if (spidma_.rx_dma_.CNDTR > 2*18) {
+        return 2;
+      } else if (spidma_.rx_dma_.CNDTR > 1*18) {
+        return 3;
+      } else {
+        return 4;
+      }
+    }
+    void start_continuous_read() {
+      dmamux_tx_regs_.CCR |= exti_num_ << DMAMUX_CxCR_SYNC_ID_Pos | 5 << DMAMUX_CxCR_NBREQ_Pos | 2 << DMAMUX_CxCR_SPOL_Pos | DMAMUX_CxCR_SE;
+      dmamux_rx_regs_.CCR |= 5 << DMAMUX_CxCR_NBREQ_Pos | DMAMUX_CxCR_EGE;
+      spidma_.start_continuous_readwrite(command_mult_[0][0], data_mult_[0][0], sizeof(command_mult_));
+      // start automatic CS
+      //HRTIM1->sTimerxRegs[0].TIMxDIER = HRTIM_TIMDIER_CMP1DE;
+      start_cs_trigger_();
+     // HRTIM1->sTimerxRegs[0].CMP1xR = 47000;
+      //DMA1_Channel5->CCR = DMA_CCR_CIRC | DMA_CCR_DIR | DMA_CCR_EN | DMA_CCR_MINC | DMA_CCR_MSIZE_1 | DMA_CCR_PSIZE_1;
+    }
+    void stop_continuous_read() {
+      // stop automatic CS
+     // DMA1_Channel5->CCR = 0;
+     // HRTIM1->sTimerxRegs[0].CMP1xR = 0;
+      //HRTIM1->sTimerxRegs[0].TIMxDIER = 0;
+      stop_cs_trigger_and_wait_cs_high_();
+      // wait for CS high
+      //while(!(GPIOD->IDR & 0x4));
+      spidma_.stop_continuous_readwrite();
+      dmamux_tx_regs_.CCR &= DMAMUX_CxCR_DMAREQ_ID_Msk;
+      dmamux_rx_regs_.CCR &= DMAMUX_CxCR_DMAREQ_ID_Msk;
+    }
+
+    uint8_t command_mult_[6][3][6] = {};
+    uint8_t data_mult_[6][3][6] = {};
+    ICPZ &icpz_;
+    ICPZ &icpz2_;
+    SPIDMA &spidma_;
+
+    bool inited_ = false;
+    DMAMUX_Channel_TypeDef &dmamux_tx_regs_;
+    DMAMUX_Channel_TypeDef &dmamux_rx_regs_;
+    uint8_t exti_num_;
+    void (*start_cs_trigger_)();
+    void (*stop_cs_trigger_and_wait_cs_high_)();
+};

--- a/sensors/encoders/stm32g4/icpz_dma.h
+++ b/sensors/encoders/stm32g4/icpz_dma.h
@@ -8,7 +8,8 @@ class ICPZDMA : public ICPZBase<ICPZDMA> {
       void(*start_cs_trigger)(), void(*stop_cs_trigger_and_wait_cs_high)(), Disk disk = Default) : 
       ICPZBase(spidma, disk), dmamux_tx_regs_(tx_dmamux), dmamux_rx_regs_(rx_dmamux), exti_num_(exti_num),
       start_cs_trigger_(start_cs_trigger), stop_cs_trigger_and_wait_cs_high_(stop_cs_trigger_and_wait_cs_high) {
-
+      spidma_.pause_.start_callback_ = [this]{start_continuous_read();};
+      spidma_.pause_.stop_callback_ = [this]{stop_continuous_read();};
     }
 
     bool init() {

--- a/sensors/encoders/stm32g4/icpz_dma.h
+++ b/sensors/encoders/stm32g4/icpz_dma.h
@@ -20,7 +20,7 @@ class ICPZDMA : public ICPZBase<ICPZDMA> {
     }
     void trigger() {}
     int32_t read() {
-      if (!*register_operation_) {
+      if (!spidma_.pause_.is_paused()) {
         // Can only read when transactions are not active. Must be guaranteed 
         // by timing setup.
         uint32_t data = ((data_[1] << 16) | (data_[2] << 8) | data_[3]) << 8;
@@ -41,7 +41,6 @@ class ICPZDMA : public ICPZBase<ICPZDMA> {
         if (!diag.nErr) {
           //clear_diag();
         }
-        ongoing_read_ = false;
       }
       return get_value();
     }
@@ -66,19 +65,6 @@ class ICPZDMA : public ICPZBase<ICPZDMA> {
       spidma_.stop_continuous_readwrite();
       dmamux_tx_regs_.CCR &= DMAMUX_CxCR_DMAREQ_ID_Msk;
       dmamux_rx_regs_.CCR &= DMAMUX_CxCR_DMAREQ_ID_Msk;
-    }
-
-    void set_register_operation_impl() {
-      (*register_operation_)++;
-      if (inited_ && *register_operation_ == 1) {
-        stop_continuous_read();
-      }
-    }
-    void clear_register_operation_impl() {
-      if (inited_ && *register_operation_ == 1) {
-        start_continuous_read();
-      }
-      (*register_operation_)--;
     }
 
     bool inited_ = false;

--- a/sensors/torque/max11254.h
+++ b/sensors/torque/max11254.h
@@ -131,10 +131,10 @@ class MAX11254 : public TorqueSensorBase {
         register_address reg = {.rw = 0, .addr = address, .bits2 = 3};
         uint8_t data_out[3] = {reg.word, value};
         uint8_t data_in[3];
-        spi_dma_.readwrite(data_out, data_in, 2, true);
+        spi_dma_.readwrite(data_out, data_in, 2);
         reg.rw = 1;
         data_out[0] = reg.word;
-        spi_dma_.readwrite(data_out, data_in, 3, true);
+        spi_dma_.readwrite(data_out, data_in, 3);
         uint16_t read_value = data_in[2];
         if (read_value != value) {
             logger.log_printf("max11254 register error %d: wrote %02x, read %02x", address, value, read_value);
@@ -147,10 +147,10 @@ class MAX11254 : public TorqueSensorBase {
         register_address reg = {.rw = 0, .addr = address, .bits2 = 3};
         uint8_t data_out[5] = {reg.word, (uint8_t) (value>>8 & 0xff), (uint8_t) (value & 0xff)};
         uint8_t data_in[5];
-        spi_dma_.readwrite(data_out, data_in, 3, true);
+        spi_dma_.readwrite(data_out, data_in, 3);
         reg.rw = 1;
         data_out[0] = reg.word;
-        spi_dma_.readwrite(data_out, data_in, 4, true);
+        spi_dma_.readwrite(data_out, data_in, 4);
         uint8_t read_value = data_in[2] << 8 | data_in[3];
         if (read_value != value) {
             logger.log_printf("max11254 register error %d: wrote %02x, read %02x", address, value, read_value);
@@ -163,10 +163,10 @@ class MAX11254 : public TorqueSensorBase {
         register_address reg = {.rw = 1, .addr = address, .bits2 = 3};
         uint8_t data_out[5] = {reg.word, (uint8_t) (value>>16 & 0xff), (uint8_t) (value>>8 & 0xff), (uint8_t) (value & 0xff)};
         uint8_t data_in[5];
-        spi_dma_.readwrite(data_out, data_in, 4, true);
+        spi_dma_.readwrite(data_out, data_in, 4);
         reg.rw = 0;
         data_out[0] = reg.word;
-        spi_dma_.readwrite(data_out, data_in, 5, true);
+        spi_dma_.readwrite(data_out, data_in, 5);
         uint32_t read_value = data_in[2] << 16 | data_in[3] << 8 | data_in[4];
         if (read_value != value) {
             logger.log_printf("max11254 register error %d: wrote %06x, read %06x", address, value, read_value);
@@ -180,10 +180,8 @@ class MAX11254 : public TorqueSensorBase {
             return;
         }
         count_ = 0;
-        if (!*spi_dma_.register_operation_) {
-            ongoing_read_ = true;
-            spi_dma_.start_readwrite(data_out_, data_in_, length_);
-        }
+        ongoing_read_ = true;
+        spi_dma_.start_readwrite(data_out_, data_in_, length_);
     }
 
     float read() {


### PR DESCRIPTION
Major refactor to remove spi "register_operation" flag. Will now use a more generic spi.claim/release. The claim and release centers around a SPIPause object that is common to each hardware spi instance.