### PR TITLE
icpz api cleanup

### DIFF
--- a/sensors/encoders/icpz.h
+++ b/sensors/encoders/icpz.h
@@ -31,6 +31,7 @@ static uint8_t CRC_BiSS_43_30bit (uint32_t w_InputData);
     api.add_api_variable(prefix "value", new const APIInt32(&icpz.pos_));\
     api.add_api_variable(prefix "diag", new const APICallback([](){ return icpz.read_diagnosis(); }));\
     api.add_api_variable(prefix "conf_write", new const APICallback([](){ return icpz.write_conf(); }));\
+    api.add_api_variable(prefix "conf_write_no_check", new const APICallback([](){ return icpz.write_conf_no_check(); }));\
     api.add_api_variable(prefix "auto_ana", new const APICallback([](){ icpz.start_auto_adj_ana(); return "ok"; }));\
     api.add_api_variable(prefix "auto_dig", new const APICallback([](){ icpz.start_auto_adj_dig(); return "ok"; }));\
     api.add_api_variable(prefix "readj_dig", new const APICallback([](){ icpz.start_auto_readj_dig(); return "ok"; }));\
@@ -274,6 +275,11 @@ class ICPZBase : public EncoderBase {
         } else {
           return "conf error: " + std::to_string(data[0]);
         }
+    }
+
+    std::string write_conf_no_check() {
+        set_register(0, Addr::COMMANDS, {CMD::CONF_WRITE_ALL});
+        return "ok";
     }
 
     void start_auto_adj_ana() {

--- a/sensors/encoders/icpz.h
+++ b/sensors/encoders/icpz.h
@@ -90,29 +90,29 @@ class ICPZBase : public EncoderBase {
       IWDG->KR = 0xAAAA;
 
       //set_register(7, 9, {0});
-      success = set_register(0, 0, {3}) ? success : false; // fast speed on port a, set first
-      success = set_register(7, 9, {0}) ? success : false; // multiturn data length = 0
-      success = set_register(7, 0xA, {0}) ? success : false; // spi_ext = 0
+      success &= set_register(0, 0, {3}); // fast speed on port a, set first
+      success &= set_register(7, 9, {0}); // multiturn data length = 0
+      success &= set_register(7, 0xA, {0}); // spi_ext = 0
       success &= set_register(7, 0, {0x13, 0x07, 0, 0x11}); // disable prc error, default: {0x13, 0x0F, 0, 0x11}, 
       success &= set_register(7, 4, {0x0C, 0xC8, 0, 0x02}); // prc is a warning, default: {0x0C, 0xC0, 0, 0x02}, 
-      success = set_register(0, 0xF, {4}) ? success : false; // 0x00 ran_fld = 0 -> never update position based on absolute track after initial, tol 4
-      success = set_register(2, 3, {0x77}) ? success : false; // moderate dynamic digital calibration
-      success = set_register(2, 0, {0x77, 0x7}) ? success: false; // moderate dynamic analog calibration
+      success &= set_register(0, 0xF, {4});  // 0x00 ran_fld = 0 -> never update position based on absolute track after initial, tol 4
+      success &= set_register(2, 3, {0x77}); // moderate dynamic digital calibration
+      success &= set_register(2, 0, {0x77, 0x7});  // moderate dynamic analog calibration
+      success &= set_register(0, 3, {0x6e}); // ipo_filt1 per datasheet
 
       if (disk_ == PZ03S) {
-        success = set_register(8, 0, {0, 1}) ? success : false; // fcl = 256
-        success = set_register(8, 2, {0, 0}) ? success : false; // fcs = 0
-        success = set_register(0, 7, {8 << 4}) ? success : false; // sys_ovr = 8
-        //success = set_register(1, 0xB, {9}) ? success : false; // ai_scale = 9 (1.0048),
+        success &= set_register(8, 0, {0, 1}); // fcl = 256
+        success &= set_register(8, 2, {0, 0}); // fcs = 0
+        success &= set_register(0, 7, {8 << 4}); // sys_ovr = 8
       } else if (disk_ == PZ08S) {
-        success = set_register(8, 0, {0xBE, 1}) ? success : false; // fcl = 446 (0x1BE)
-        success = set_register(8, 2, {216, 0}) ? success : false; // fcs = 216
-        success = set_register(0, 7, {9 << 4}) ? success : false; // sys_ovr = 9
+        success &= set_register(8, 0, {0xBE, 1}); // fcl = 446 (0x1BE)
+        success &= set_register(8, 2, {216, 0}); // fcs = 216
+        success &= set_register(0, 7, {9 << 4}); // sys_ovr = 9
         // ai phase -20
       } else if (disk_ == PZ16S) {
-        success = set_register(8, 0, {172, 0}) ? success : false; // fcl = 172
-        success = set_register(8, 2, {27, 0}) ? success : false; // fcs = 27
-        success = set_register(0, 7, {8 << 4}) ? success : false; // sys_ovr = 8
+        success &= set_register(8, 0, {172, 0}); // fcl = 172
+        success &= set_register(8, 2, {27, 0}); // fcs = 27
+        success &= set_register(0, 7, {8 << 4}); // sys_ovr = 8
       }
        return success;
     }
@@ -262,7 +262,12 @@ class ICPZBase : public EncoderBase {
 
     std::string write_conf() {
         set_register(0, Addr::COMMANDS, {CMD::CONF_WRITE_ALL});
-        wait_while_false_with_timeout_us(read_register(Addr::COMMANDS, 1)[0] == 0, 100);
+        // 20 ms timeout found experimentally (15 seems ok 10 too short)
+        wait_while_false_with_timeout_us(read_register(Addr::COMMANDS, 1)[0] == 0, 20000);
+        uint8_t result = read_register(Addr::COMMANDS, 1)[0];
+        if (result != 0) {
+          return "conf timeout error: " + std::to_string(result);
+        }
         auto data = read_register(Addr::CMD_STAT, 1);
         if (data[0] == 0) {
           return "conf write success";
@@ -410,14 +415,14 @@ class ICPZBase : public EncoderBase {
 
     std::string get_cal_string() {
         char c[200];
-        std::snprintf(c, 200, "cos_off: %f, sin_off: %f, sc_gain, %f, sc_phase: %f ai_phase: %f, ai_scale: %f, ecc_amp: %f, ecc_phase: %f", 
+        std::snprintf(c, 200, "cos_off: %f, sin_off: %f, sc_gain: %f, sc_phase: %f, ai_phase: %f, ai_scale: %f, ecc_amp: %f, ecc_phase: %f", 
           get_cos_off(), get_sin_off(), get_sc_gain(), get_sc_phase(), get_ai_phase(), get_ai_scale(), get_ecc_um(), get_ecc_phase());
         return std::string(c);
     }
 
     std::string get_cals_string() {
         char c[200];
-        std::snprintf(c, 200, "cos_off: %f, sin_off: %f, sc_gain, %f, sc_phase: %f ai_phase: %f, ai_scale: %f", 
+        std::snprintf(c, 200, "cos_off: %f, sin_off: %f, sc_gain: %f, sc_phase: %f, ai_phase: %f, ai_scale: %f", 
           get_cos_offs(), get_sin_offs(), get_sc_gains(), get_sc_phases(), get_ai_phases(), get_ai_scales());
         return std::string(c);
     }


### PR DESCRIPTION
Fix conf write to wait up to 20 ms for success. Note this is longer than the default api timeout of 10 ms. To not error due to timeout:
Command line
```
motor_util --set-timeout 20
```
python
```
[x.set_timout_ms(20) for x in MotorManager().get_connected_motors()]
```

Also note fixed commas in mcal/s